### PR TITLE
[KAN-74] implemented GetPost API request count metric

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
-const { createMetrics } = require('./utils/createMetrics');
+const { createMetrics } = require('./metrics/createMetrics');
 
 const app = express();
 app.use(cors());

--- a/server/src/controllers/post.js
+++ b/server/src/controllers/post.js
@@ -30,9 +30,9 @@ exports.createPost = async (req, res) => {
 exports.getPost = async (req, res) => {
   let post = null;
   const { id } = req.params;
-  const { requestCount, labels } = req.metrics;
+  const { getPostRequestCount, labels } = req.metrics;
 
-  requestCount.bind(labels).add(1);
+  getPostRequestCount.bind(labels).add(1);
 
   try {
     post = await Post.findOne({ _id: id });

--- a/server/src/metrics/createMetrics.js
+++ b/server/src/metrics/createMetrics.js
@@ -1,5 +1,6 @@
 const { MeterRegistry } = require('@opentelemetry/metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
+const { aggregatePostMetrics } = require('./postMetrics');
 
 exports.createMetrics = () => {
   const exporter = setUpPrometheus();
@@ -7,17 +8,11 @@ exports.createMetrics = () => {
   const meter = new MeterRegistry().getMeter(meterName);
   meter.addExporter(exporter);
 
-  // define metrics
-  const requestCountData = getRequestCountData();
-  const requestCount = meter.createCounter(
-    requestCountData.name,
-    requestCountData.metadata
-  );
-
+  const postMetrics = aggregatePostMetrics(meter);
   const labels = meter.labels({});
 
   return {
-    requestCount,
+    ...postMetrics,
     labels,
   };
 };
@@ -38,13 +33,4 @@ const setUpPrometheus = () => {
   );
 
   return exporter;
-};
-
-const getRequestCountData = () => {
-  return {
-    name: 'request_count',
-    metadata: {
-      description: 'Counts total number of requests',
-    },
-  };
 };

--- a/server/src/metrics/postMetrics.js
+++ b/server/src/metrics/postMetrics.js
@@ -1,0 +1,22 @@
+const GET_POST_REQUEST_COUNT = 'GetPost_RequestCount';
+
+exports.aggregatePostMetrics = (meter) => {
+  const getPostRequestCountData = buildGetPostRequestCountData();
+  const getPostRequestCount = meter.createCounter(
+    getPostRequestCountData.name,
+    getPostRequestCountData.metadata
+  );
+
+  return {
+    getPostRequestCount,
+  };
+};
+
+const buildGetPostRequestCountData = () => {
+  return {
+    name: GET_POST_REQUEST_COUNT,
+    metadata: {
+      description: 'Counts total number of GetPost API requests',
+    },
+  };
+};

--- a/server/tests/controllers/post.test.js
+++ b/server/tests/controllers/post.test.js
@@ -163,10 +163,13 @@ test('list_Posts_Success', async () => {
 });
 
 const buildMockRequest = () => {
-  const mockReq = { metrics: { requestCount: {} } };
-  const { requestCount } = mockReq.metrics;
-  requestCount.bind = jest.fn(() => requestCount);
-  requestCount.add = jest.fn();
+  const mockReq = { metrics: {} };
+
+  mockReq.metrics.getPostRequestCount = {};
+  const { getPostRequestCount } = mockReq.metrics;
+  getPostRequestCount.bind = jest.fn(() => getPostRequestCount);
+  getPostRequestCount.add = jest.fn();
+
   return mockReq;
 };
 


### PR DESCRIPTION
- separated requestCount metric by API to account for differences in API behaviour 
- implemented metrics library for reusability of metric logic
- injected request count metric into GetPost API controller 
- re-factored unit test mock request objects to be reusable and replicable across all Post related tests