### PR TITLE
[KAN-90] Delete Comment API Request Count Metric

### DIFF
--- a/server/src/controllers/comment.js
+++ b/server/src/controllers/comment.js
@@ -108,6 +108,9 @@ exports.deleteComment = async (req, res) => {
   const { id } = req.params;
   const comment = await Comment.findOne({ _id: id });
 
+  const { deleteCommentRequestCount, labels } = req.metrics;
+  deleteCommentRequestCount.bind(labels).add(1);
+
   if (!comment) {
     return res.status(RESOURCE_NOT_FOUND_STATUS_CODE).json({
       successful: false,

--- a/server/src/metrics/commentMetrics.js
+++ b/server/src/metrics/commentMetrics.js
@@ -4,6 +4,7 @@ const LIST_COMMENTS_REQUEST_COUNT = 'ListComments_RequestCount';
 const LIST_COMMENTS_LATENCY = 'ListComments_Latency';
 const UPDATE_COMMENT_REQUEST_COUNT = 'UpdateComment_RequestCount';
 const UPDATE_COMMENT_LATENCY = 'UpdateComment_Latency';
+const DELETE_COMMENT_REQUEST_COUNT = 'DeleteComment_RequestCount';
 
 exports.aggregateCommentMetrics = (meter) => {
   const createCommentRequestCountData = buildCreateCommentRequestCountData();
@@ -42,6 +43,12 @@ exports.aggregateCommentMetrics = (meter) => {
     updateCommentLatencyData.metadata
   );
 
+  const deleteCommentRequestCountData = buildDeleteCommentRequestCountData();
+  const deleteCommentRequestCount = meter.createCounter(
+    deleteCommentRequestCountData.name,
+    deleteCommentRequestCountData.metadata
+  );
+
   return {
     createCommentRequestCount: createCommentRequestCount,
     createCommentLatency: createCommentLatency,
@@ -49,6 +56,7 @@ exports.aggregateCommentMetrics = (meter) => {
     listCommentsLatency: listCommentsLatency,
     updateCommentRequestCount: updateCommentRequestCount,
     updateCommentLatency: updateCommentLatency,
+    deleteCommentRequestCount: deleteCommentRequestCount,
   };
 };
 
@@ -102,6 +110,15 @@ const buildUpdateCommentLatencyData = () => {
     name: UPDATE_COMMENT_LATENCY,
     metadata: {
       description: 'Recoreds the latency of UpdateComment API',
+    },
+  };
+};
+
+const buildDeleteCommentRequestCountData = () => {
+  return {
+    name: DELETE_COMMENT_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of DeleteComment API requests',
     },
   };
 };

--- a/server/tests/controllers/comment.test.js
+++ b/server/tests/controllers/comment.test.js
@@ -115,7 +115,8 @@ test('update_Comment_Resource_Not_Found', async () => {
 
 test('delete_Comment_Success', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Comment, 'findOne').mockResolvedValue({});
@@ -132,7 +133,8 @@ test('delete_Comment_Success', async () => {
 
 test('delete_Comment_Resource_Not_Found', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Comment, 'findOne').mockResolvedValue(null);
@@ -185,6 +187,13 @@ const buildMockRequest = () => {
   updateCommentRequestCount.add = jest.fn();
   updateCommentLatency.bind = jest.fn(() => updateCommentLatency);
   updateCommentLatency.set = jest.fn();
+
+  mockReq.metrics.deleteCommentRequestCount = {};
+
+  const { deleteCommentRequestCount } = mockReq.metrics;
+
+  deleteCommentRequestCount.bind = jest.fn(() => deleteCommentRequestCount);
+  deleteCommentRequestCount.add = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into DeleteComment API controller
- modified unit test to integrate new metric logic
- test locally via local host