### PR TITLE
[KAN-140] added request start and end logs for ListPosts API

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -4,6 +4,7 @@ const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 const path = require('path');
+const { v4 } = require('uuid');
 const { createMetrics } = require('./metrics/createMetrics');
 const { EXPRESS_STATIC_PATH } = require('./commons/constants');
 const { createLogger } = require('./utils/createLogger');
@@ -16,6 +17,7 @@ app.use(express.json());
 const metrics = createMetrics();
 const logger = createLogger();
 app.use((req, _, next) => {
+  req.id = v4();
   req.logger = logger;
   req.metrics = metrics;
   next();

--- a/server/src/commons/constants.js
+++ b/server/src/commons/constants.js
@@ -12,3 +12,5 @@ exports.DEFAULT_LIST_FOLLOWING_LIMIT = 30;
 
 exports.IMAGE_KEY = 'image';
 exports.EXPRESS_STATIC_PATH = 'public';
+
+exports.POSTS_API_CONTROLLER_LOG_GROUP = 'posts-api-controller';

--- a/server/src/controllers/post.js
+++ b/server/src/controllers/post.js
@@ -4,6 +4,7 @@ const {
   BAD_REQUEST,
   RESOURCE_NOT_FOUND_STATUS_CODE,
   DEFAULT_LIST_POSTS_LIMIT,
+  POSTS_API_CONTROLLER_LOG_GROUP,
 } = require('../commons/constants');
 const { getPageNumber } = require('../utils/getPageNumber');
 
@@ -143,10 +144,11 @@ exports.deletePost = async (req, res) => {
 
 exports.listPosts = async (req, res) => {
   const requestRecieved = new Date().getTime();
+  const logger = req.logger.getLogGroup(POSTS_API_CONTROLLER_LOG_GROUP);
+  logger.info(`START ${req.id} Method: GET Api: ListPosts`);
 
   const { username } = req.params;
   const { listPostsRequestCount, listPostsLatency, labels } = req.metrics;
-
   listPostsRequestCount.bind(labels).add(1);
 
   const pageSize = req.query.pageSize || DEFAULT_LIST_POSTS_LIMIT;
@@ -159,6 +161,7 @@ exports.listPosts = async (req, res) => {
   const latency = new Date().getTime() - requestRecieved;
   listPostsLatency.bind(labels).set(latency);
 
+  logger.info(`END ${req.id} Method: GET Api: ListPosts`);
   return res.status(OK_STATUS_CODE).json({
     successful: true,
     posts,

--- a/server/src/utils/createLogger.js
+++ b/server/src/utils/createLogger.js
@@ -1,36 +1,50 @@
 const fs = require('fs');
 const path = require('path');
-const { EXPRESS_STATIC_PATH } = require('../commons/constants');
+const {
+  EXPRESS_STATIC_PATH,
+  POSTS_API_CONTROLLER_LOG_GROUP,
+} = require('../commons/constants');
 
 const ERROR_SEVERITY = 'ERROR';
 const WARNING_SEVERITY = 'WARN';
 const INFO_SEVERITY = 'INFO';
-const LOGS_FILE_NAME = 'logs.txt';
 
-const filePath = path.join(
-  __dirname,
-  '../../',
-  EXPRESS_STATIC_PATH,
-  LOGS_FILE_NAME
-);
+const LOGS_FILE_MAP = {
+  [POSTS_API_CONTROLLER_LOG_GROUP]: 'posts-api-controller.txt',
+};
 
 exports.createLogger = () => {
   const logger = {
-    info: (text) => {
-      const content = formatContent(INFO_SEVERITY, text);
-      fs.appendFile(filePath, content, (_) => _);
-    },
-    warn: (text) => {
-      const content = formatContent(WARNING_SEVERITY, text);
-      fs.appendFile(filePath, content, (_) => _);
-    },
-    error: (text) => {
-      const content = formatContent(ERROR_SEVERITY, text);
-      fs.appendFile(filePath, content, (_) => _);
+    getLogGroup: (logGroupName) => {
+      const filePath = getFilePath(logGroupName);
+
+      return {
+        info: (text) => {
+          const content = formatContent(INFO_SEVERITY, text);
+          fs.appendFile(filePath, content, (_) => _);
+        },
+        warn: (text) => {
+          const content = formatContent(WARNING_SEVERITY, text);
+          fs.appendFile(filePath, content, (_) => _);
+        },
+        error: (text) => {
+          const content = formatContent(ERROR_SEVERITY, text);
+          fs.appendFile(filePath, content, (_) => _);
+        },
+      };
     },
   };
 
   return logger;
+};
+
+const getFilePath = (logGroupName) => {
+  return path.join(
+    __dirname,
+    '../../',
+    EXPRESS_STATIC_PATH,
+    LOGS_FILE_MAP[logGroupName]
+  );
 };
 
 const formatContent = (severity, text) => {

--- a/server/tests/controllers/post.test.js
+++ b/server/tests/controllers/post.test.js
@@ -176,7 +176,9 @@ test('list_Posts_Success', async () => {
 });
 
 const buildMockRequest = () => {
-  const mockReq = { metrics: {} };
+  const mockReq = { metrics: {}, logger: {} };
+  mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
+  mockReq.logger.info = jest.fn();
 
   mockReq.metrics.getPostRequestCount = {};
   mockReq.metrics.getPostLatency = {};


### PR DESCRIPTION
- split logger into log groups to isolate requests into different suites depending on the type of API
- injected request id using express middleware for better tracing on request logs 
- mocked request logger in unit tests