### PR TITLE
[KAN-145] ListLikes API Request Start/End Logs

### DIFF
--- a/server/src/commons/constants.js
+++ b/server/src/commons/constants.js
@@ -14,3 +14,4 @@ exports.IMAGE_KEY = 'image';
 exports.EXPRESS_STATIC_PATH = 'public';
 
 exports.POSTS_API_CONTROLLER_LOG_GROUP = 'posts-api-controller';
+exports.LIKES_API_CONTROLLER_LOG_GROUP = 'likes-api-controller';

--- a/server/src/controllers/like.js
+++ b/server/src/controllers/like.js
@@ -2,6 +2,7 @@ const {
   BAD_REQUEST,
   OK_STATUS_CODE,
   RESOURCE_NOT_FOUND_STATUS_CODE,
+  LIKES_API_CONTROLLER_LOG_GROUP,
 } = require('../commons/constants');
 const Like = require('../models/like');
 
@@ -27,8 +28,13 @@ exports.createLike = async (req, res) => {
 };
 
 exports.listLikes = async (req, res) => {
+  const logger = req.logger.getLogGroup(LIKES_API_CONTROLLER_LOG_GROUP);
+  logger.info(`START ${req.id} Method GET Api: ListLikes`);
+
   const { postId } = req.params;
   const likes = await Like.find({ postId: postId });
+
+  logger.info(`END ${req.id} Method: GET Api : ListLikes`);
   return res.status(OK_STATUS_CODE).json({
     successful: true,
     likes,

--- a/server/src/utils/createLogger.js
+++ b/server/src/utils/createLogger.js
@@ -3,6 +3,7 @@ const path = require('path');
 const {
   EXPRESS_STATIC_PATH,
   POSTS_API_CONTROLLER_LOG_GROUP,
+  LIKES_API_CONTROLLER_LOG_GROUP,
 } = require('../commons/constants');
 
 const ERROR_SEVERITY = 'ERROR';
@@ -11,6 +12,7 @@ const INFO_SEVERITY = 'INFO';
 
 const LOGS_FILE_MAP = {
   [POSTS_API_CONTROLLER_LOG_GROUP]: 'posts-api-controller.txt',
+  [LIKES_API_CONTROLLER_LOG_GROUP]: 'likes-api-controller.txt',
 };
 
 exports.createLogger = () => {

--- a/server/tests/controllers/like.test.js
+++ b/server/tests/controllers/like.test.js
@@ -47,7 +47,9 @@ test('create_Like_Returns_400', async () => {
 
 test('list_Likes_Success', async () => {
   const mockPostId = '1234abc';
-  const mockReq = { params: { mockPostId: mockPostId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { postId: mockPostId };
+
   const mockRes = buildMockResponse();
 
   jest.spyOn(Like, 'find').mockResolvedValue([{}]);
@@ -99,4 +101,11 @@ const buildMockResponse = () => {
   mockRes.json = jest.fn();
   mockRes.status = jest.fn(() => mockRes);
   return mockRes;
+};
+
+const buildMockRequest = () => {
+  const mockReq = { logger: {} };
+  mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
+  mockReq.logger.info = jest.fn();
+  return mockReq;
 };


### PR DESCRIPTION
- created new log group to isolate requests into unique suite for Likes APIs
- logged start/end of request in ListLikes API
- mocked request logger in unit tests