### PR TITLE
[NO-TICKET] modified console logger to have more compact logs on command line

### DIFF
--- a/server/src/utils/createLogger.js
+++ b/server/src/utils/createLogger.js
@@ -29,19 +29,19 @@ exports.createLogger = () => {
       return {
         info: (text) => {
           const content = formatContent(INFO_SEVERITY, text);
-          console.log(content);
+          process.stdout.write(content);
 
           fs.appendFile(filePath, content, (_) => _);
         },
         warn: (text) => {
           const content = formatContent(WARNING_SEVERITY, text);
-          console.log(content);
+          process.stdout.write(content);
 
           fs.appendFile(filePath, content, (_) => _);
         },
         error: (text) => {
           const content = formatContent(ERROR_SEVERITY, text);
-          console.log(content);
+          process.stdout.write(content);
 
           fs.appendFile(filePath, content, (_) => _);
         },


### PR DESCRIPTION
- utilized process.stdout.write as an alternative for console.log
- result: compact logs in the command line during the debugging phase 