### PR TITLE
[KAN-154] DeleteLike API Request Count Metric

### DIFF
--- a/server/src/controllers/like.js
+++ b/server/src/controllers/like.js
@@ -61,6 +61,10 @@ exports.listLikes = async (req, res) => {
 
 exports.deleteLike = async (req, res) => {
   const { id } = req.params;
+
+  const { deleteLikeRequestCount, labels } = req.metrics;
+  deleteLikeRequestCount.bind(labels).add(1);
+
   const like = await Like.findOne({ _id: id });
 
   if (!like) {

--- a/server/src/metrics/likeMetrics.js
+++ b/server/src/metrics/likeMetrics.js
@@ -2,6 +2,7 @@ const CREATE_LIKE_REQUEST_COUNT = 'CreateLike_RequestCount';
 const CREATE_LIKE_LATENCY = 'CreateLike_Latency';
 const LIST_LIKES_REQUEST_COUNT = 'ListLikes_RequestCount';
 const LIST_LIKES_LATENCY = 'ListLikes_Latency';
+const DELETE_LIKE_REQUEST_COUNT = 'DeleteLike_RequestCount';
 
 exports.aggregateLikeMetrics = (meter) => {
   const createLikeRequestCountData = buildCreateLikeRequestCountData();
@@ -28,11 +29,18 @@ exports.aggregateLikeMetrics = (meter) => {
     listLikesLatencyData.metadata
   );
 
+  const deleteLikeRequestCountData = buildDeleteLikeRequestCountData();
+  const deleteLikeRequestCount = meter.createCounter(
+    deleteLikeRequestCountData.name,
+    deleteLikeRequestCountData.metadata
+  );
+
   return {
     createLikeRequestCount: createLikeRequestCount,
     createLikeLatency: createLikeLatency,
     listLikesRequestCount: listLikesRequestCount,
     listLikesLatency: listLikesLatency,
+    deleteLikeRequestCount: deleteLikeRequestCount,
   };
 };
 
@@ -68,6 +76,15 @@ const buildListLikesLatencyData = () => {
     name: LIST_LIKES_LATENCY,
     metadata: {
       description: 'Records the latency of ListLikes API',
+    },
+  };
+};
+
+const buildDeleteLikeRequestCountData = () => {
+  return {
+    name: DELETE_LIKE_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of DeleteLike API requests',
     },
   };
 };

--- a/server/tests/controllers/like.test.js
+++ b/server/tests/controllers/like.test.js
@@ -64,7 +64,9 @@ test('list_Likes_Success', async () => {
 
 test('delete_Like_Success', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
+
   const mockRes = buildMockResponse();
 
   jest.spyOn(Like, 'findOne').mockResolvedValue({});
@@ -81,7 +83,8 @@ test('delete_Like_Success', async () => {
 
 test('delete_Like_Resource_Not_Found', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Like, 'findOne').mockResolvedValue(null);
@@ -126,6 +129,13 @@ const buildMockRequest = () => {
   listLikesRequestCount.add = jest.fn();
   listLikesLatency.bind = jest.fn(() => listLikesLatency);
   listLikesLatency.set = jest.fn();
+
+  mockReq.metrics.deleteLikeRequestCount = {};
+
+  const { deleteLikeRequestCount } = mockReq.metrics;
+
+  deleteLikeRequestCount.bind = jest.fn(() => deleteLikeRequestCount);
+  deleteLikeRequestCount.add = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into DeleteLike API controller
- modified unit test to integrate new metric logic
- test locally via local host