### PR TITLE
[KAN-155] DeleteLike API Latency Metric

### DIFF
--- a/server/src/metrics/likeMetrics.js
+++ b/server/src/metrics/likeMetrics.js
@@ -3,6 +3,7 @@ const CREATE_LIKE_LATENCY = 'CreateLike_Latency';
 const LIST_LIKES_REQUEST_COUNT = 'ListLikes_RequestCount';
 const LIST_LIKES_LATENCY = 'ListLikes_Latency';
 const DELETE_LIKE_REQUEST_COUNT = 'DeleteLike_RequestCount';
+const DELETE_LIKE_LATENCY = 'DeleteLike_Latency';
 
 exports.aggregateLikeMetrics = (meter) => {
   const createLikeRequestCountData = buildCreateLikeRequestCountData();
@@ -35,12 +36,19 @@ exports.aggregateLikeMetrics = (meter) => {
     deleteLikeRequestCountData.metadata
   );
 
+  const deleteLikeLatencyData = buildDeleteLikeLatencyData();
+  const deleteLikeLatency = meter.createGauge(
+    deleteLikeLatencyData.name,
+    deleteLikeLatencyData.metadata
+  );
+
   return {
     createLikeRequestCount: createLikeRequestCount,
     createLikeLatency: createLikeLatency,
     listLikesRequestCount: listLikesRequestCount,
     listLikesLatency: listLikesLatency,
     deleteLikeRequestCount: deleteLikeRequestCount,
+    deleteLikeLatency,
   };
 };
 
@@ -85,6 +93,15 @@ const buildDeleteLikeRequestCountData = () => {
     name: DELETE_LIKE_REQUEST_COUNT,
     metadata: {
       description: 'Count total number of DeleteLike API requests',
+    },
+  };
+};
+
+const buildDeleteLikeLatencyData = () => {
+  return {
+    name: DELETE_LIKE_LATENCY,
+    metadata: {
+      desdription: 'Records the latency of DeleteLike API',
     },
   };
 };

--- a/server/tests/controllers/like.test.js
+++ b/server/tests/controllers/like.test.js
@@ -131,11 +131,14 @@ const buildMockRequest = () => {
   listLikesLatency.set = jest.fn();
 
   mockReq.metrics.deleteLikeRequestCount = {};
+  mockReq.metrics.deleteLikeLatency = {};
 
-  const { deleteLikeRequestCount } = mockReq.metrics;
+  const { deleteLikeRequestCount, deleteLikeLatency } = mockReq.metrics;
 
   deleteLikeRequestCount.bind = jest.fn(() => deleteLikeRequestCount);
   deleteLikeRequestCount.add = jest.fn();
+  deleteLikeLatency.bind = jest.fn(() => deleteLikeLatency);
+  deleteLikeLatency.set = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
- implemented latency metric for DeleteLike API
- latency recorded in both status 200 and 404 situations
- tested locally via local host