### PR TITLE
[KAN-165] ListFollowers API Request Count Metric

### DIFF
--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -47,6 +47,9 @@ exports.listFollowers = async (req, res) => {
 
   const { username } = req.params;
 
+  const { listFollowersRequestCount, labels } = req.metrics;
+  listFollowersRequestCount.bind(labels).add(1);
+
   const pageSize = req.query.pageSize || DEFAULT_LIST_FOLLOWERS_LIMIT;
   const page = getPageNumber(req.query.page);
 

--- a/server/src/metrics/followMetrics.js
+++ b/server/src/metrics/followMetrics.js
@@ -1,5 +1,6 @@
 const CREATE_FOLLOW_REQUEST_COUNT = 'CreateFollow_RequestCount';
 const CREATE_FOLLOW_LATENCY = 'CreateFollow_Latency';
+const LIST_FOLLOWERS_REQUEST_COUNT = 'ListFollowers_RequestCount';
 
 exports.aggregateFollowMetrics = (meter) => {
   const createFollowRequestCountData = buildCreateFollowRequestCountData();
@@ -14,9 +15,16 @@ exports.aggregateFollowMetrics = (meter) => {
     createFollowLatencyData.metadata
   );
 
+  const listFollowersRequestCountData = buildListFollowersRequestCountData();
+  const listFollowersRequestCount = meter.createCounter(
+    listFollowersRequestCountData.name,
+    listFollowersRequestCountData.metadata
+  );
+
   return {
     createFollowRequestCount: createFollowRequestCount,
     createFollowLatency: createFollowLatency,
+    listFollowersRequestCount: listFollowersRequestCount,
   };
 };
 
@@ -34,6 +42,15 @@ const buildCreateFollowLatencyData = () => {
     name: CREATE_FOLLOW_LATENCY,
     metadata: {
       description: 'Records the latency of CreateFollow API',
+    },
+  };
+};
+
+const buildListFollowersRequestCountData = () => {
+  return {
+    name: LIST_FOLLOWERS_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of ListFollowers API requests',
     },
   };
 };

--- a/server/tests/controllers/follow.test.js
+++ b/server/tests/controllers/follow.test.js
@@ -150,5 +150,12 @@ const buildMockRequest = () => {
   createFollowLatency.bind = jest.fn(() => createFollowLatency);
   createFollowLatency.set = jest.fn();
 
+  mockReq.metrics.listFollowersRequestCount = {};
+
+  const { listFollowersRequestCount } = mockReq.metrics;
+
+  listFollowersRequestCount.bind = jest.fn(() => listFollowersRequestCount);
+  listFollowersRequestCount.add = jest.fn();
+
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into ListFollowers API controller
- modified unit test to integrate new metric logic
- test locally via local host