### PR TITLE
[KAN-168] ListFollowing API Request Count Metric

### DIFF
--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -76,6 +76,9 @@ exports.listFollowing = async (req, res) => {
 
   const { username } = req.params;
 
+  const { listFollowingRequestCount, labels } = req.metrics;
+  listFollowingRequestCount.bind(labels).add(1);
+
   const pageSize = req.query.pageSize || DEFAULT_LIST_FOLLOWING_LIMIT;
   const page = getPageNumber(req.query.page);
 

--- a/server/src/metrics/followMetrics.js
+++ b/server/src/metrics/followMetrics.js
@@ -2,6 +2,7 @@ const CREATE_FOLLOW_REQUEST_COUNT = 'CreateFollow_RequestCount';
 const CREATE_FOLLOW_LATENCY = 'CreateFollow_Latency';
 const LIST_FOLLOWERS_REQUEST_COUNT = 'ListFollowers_RequestCount';
 const LIST_FOLLOWERS_LATENCY = 'ListFollowers_Latency';
+const LIST_FOLLOWING_REQUEST_COUNT = 'ListFollowing_RequestCount';
 
 exports.aggregateFollowMetrics = (meter) => {
   const createFollowRequestCountData = buildCreateFollowRequestCountData();
@@ -28,11 +29,18 @@ exports.aggregateFollowMetrics = (meter) => {
     listFollowersLatencyData.metadata
   );
 
+  const listFollowingRequestCountData = buildListFollowingRequestCountData();
+  const listFollowingRequestCount = meter.createCounter(
+    listFollowingRequestCountData.name,
+    listFollowingRequestCountData.metadata
+  );
+
   return {
     createFollowRequestCount: createFollowRequestCount,
     createFollowLatency: createFollowLatency,
     listFollowersRequestCount: listFollowersRequestCount,
     listFollowersLatency: listFollowersLatency,
+    listFollowingRequestCount: listFollowingRequestCount,
   };
 };
 
@@ -68,6 +76,15 @@ const buildListFollowersLatencyData = () => {
     name: LIST_FOLLOWERS_LATENCY,
     metadata: {
       description: 'Records the latency of ListFollowers API',
+    },
+  };
+};
+
+const buildListFollowingRequestCountData = () => {
+  return {
+    name: LIST_FOLLOWING_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of ListFollowing API requests',
     },
   };
 };

--- a/server/tests/controllers/follow.test.js
+++ b/server/tests/controllers/follow.test.js
@@ -161,5 +161,12 @@ const buildMockRequest = () => {
   listFollowersLatency.bind = jest.fn(() => listFollowersLatency);
   listFollowersLatency.set = jest.fn();
 
+  mockReq.metrics.listFollowingRequestCount = {};
+
+  const { listFollowingRequestCount } = mockReq.metrics;
+
+  listFollowingRequestCount.bind = jest.fn(() => listFollowingRequestCount);
+  listFollowingRequestCount.add = jest.fn();
+
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into ListFollowing API controller
- modified unit test to integrate new metric logic
- test locally via local host