### PR TITLE
[KAN-170] Create Follow API Request Start/End Logs

### DIFF
--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -11,6 +11,10 @@ const { getPageNumber } = require('../utils/getPageNumber');
 
 exports.createFollow = async (req, res) => {
   const requestRecieved = new Date().getTime();
+
+  const logger = req.logger.getLogGroup(FOLLOW_API_CONTROLLER_LOG_GROUP);
+  logger.info(`START ${req.id} Method: POST Api: createFollow`);
+
   let follow = null;
 
   const { createFollowRequestCount, createFollowLatency, labels } = req.metrics;
@@ -26,6 +30,8 @@ exports.createFollow = async (req, res) => {
     const latency = requestRecieved - new Date().getTime();
     createFollowLatency.bind(labels).set(latency);
 
+    logger.error(error);
+
     return res.status(BAD_REQUEST).json({
       successful: false,
       follow,
@@ -34,6 +40,8 @@ exports.createFollow = async (req, res) => {
 
   const latency = new Date().getTime() - requestRecieved;
   createFollowLatency.bind(labels).set(latency);
+
+  logger.info(`END ${req.id} Method: POST Api: createFollow`);
 
   return res.status(OK_STATUS_CODE).json({
     successful: true,

--- a/server/tests/controllers/follow.test.js
+++ b/server/tests/controllers/follow.test.js
@@ -139,6 +139,7 @@ const buildMockRequest = () => {
   const mockReq = { metrics: {}, logger: {} };
   mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
   mockReq.logger.info = jest.fn();
+  mockReq.logger.error = jest.fn();
 
   mockReq.metrics.createFollowRequestCount = {};
   mockReq.metrics.createFollowLatency = {};


### PR DESCRIPTION
- logged start/end of request in CreateFollow API
- added logs on 400 Bad Request Error Case
- mocked request logger error component in unit tests