### PR TITLE
[174] Delete Follow API Request Count Metric

### DIFF
--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -108,6 +108,9 @@ exports.listFollowing = async (req, res) => {
 };
 
 exports.deleteFollow = async (req, res) => {
+  const { deleteFollowRequestCount, labels } = req.metrics;
+  deleteFollowRequestCount.bind(labels).add(1);
+
   const { id } = req.params;
   const follow = await Follow.findOne({ _id: id });
 

--- a/server/src/metrics/followMetrics.js
+++ b/server/src/metrics/followMetrics.js
@@ -4,6 +4,7 @@ const LIST_FOLLOWERS_REQUEST_COUNT = 'ListFollowers_RequestCount';
 const LIST_FOLLOWERS_LATENCY = 'ListFollowers_Latency';
 const LIST_FOLLOWING_REQUEST_COUNT = 'ListFollowing_RequestCount';
 const LIST_FOLLOWING_REQUEST_LATENCY = 'ListFollowing_Latency';
+const DELETE_FOLLOW_REQUEST_COUNT = 'DeleteFollow_RequestCount';
 
 exports.aggregateFollowMetrics = (meter) => {
   const createFollowRequestCountData = buildCreateFollowRequestCountData();
@@ -42,6 +43,12 @@ exports.aggregateFollowMetrics = (meter) => {
     listFollowingLatencyData.metadata
   );
 
+  const deleteFollowRequestCountData = buildDeleteFollowRequestCountData();
+  const deleteFollowRequestCount = meter.createCounter(
+    deleteFollowRequestCountData.name,
+    deleteFollowRequestCountData.metadata
+  );
+
   return {
     createFollowRequestCount: createFollowRequestCount,
     createFollowLatency: createFollowLatency,
@@ -49,6 +56,7 @@ exports.aggregateFollowMetrics = (meter) => {
     listFollowersLatency: listFollowersLatency,
     listFollowingRequestCount: listFollowingRequestCount,
     listFollowingLatency: listFollowingLatency,
+    deleteFollowRequestCount: deleteFollowRequestCount,
   };
 };
 
@@ -102,6 +110,15 @@ const buildListFollowingLatencyData = () => {
     name: LIST_FOLLOWING_REQUEST_LATENCY,
     metadata: {
       description: 'Records the latency of ListFollowing API',
+    },
+  };
+};
+
+const buildDeleteFollowRequestCountData = () => {
+  return {
+    name: DELETE_FOLLOW_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of DeleteFollow API requests',
     },
   };
 };

--- a/server/tests/controllers/follow.test.js
+++ b/server/tests/controllers/follow.test.js
@@ -96,7 +96,8 @@ test('list_Following_Success', async () => {
 
 test('delete_Follow_Success', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Follow, 'findOne').mockResolvedValue({});
@@ -113,7 +114,8 @@ test('delete_Follow_Success', async () => {
 
 test('delete_Follow_Resource_Not_Found', async () => {
   const mockId = '1234';
-  const mockReq = { params: { id: mockId } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { id: mockId };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Follow, 'findOne').mockResolvedValue(null);
@@ -172,6 +174,13 @@ const buildMockRequest = () => {
   listFollowingRequestCount.add = jest.fn();
   listFollowingLatency.bind = jest.fn(() => listFollowingLatency);
   listFollowingLatency.set = jest.fn();
+
+  mockReq.metrics.deleteFollowRequestCount = {};
+
+  const { deleteFollowRequestCount } = mockReq.metrics;
+
+  deleteFollowRequestCount.bind = jest.fn(() => deleteFollowRequestCount);
+  deleteFollowRequestCount.add = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into DeleteFollow API controller
- modified unit test to integrate new metric logic
- test locally via local host