### PR TITLE
[KAN-176] Delete Follow Api Request Start/End Logs

### DIFF
--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -120,6 +120,9 @@ exports.deleteFollow = async (req, res) => {
   const follow = await Follow.findOne({ _id: id });
 
   if (!follow) {
+    const latency = new Date().getTime() - requestRecieved;
+    deleteFollowLatency.bind(labels).set(latency);
+
     logger.warn(`Follow with id: ${id} does not exist`);
 
     return res.status(RESOURCE_NOT_FOUND_STATUS_CODE).json({

--- a/server/src/controllers/follow.js
+++ b/server/src/controllers/follow.js
@@ -110,6 +110,9 @@ exports.listFollowing = async (req, res) => {
 exports.deleteFollow = async (req, res) => {
   const requestRecieved = new Date().getTime();
 
+  const logger = req.logger.getLogGroup(FOLLOW_API_CONTROLLER_LOG_GROUP);
+  logger.info(`START ${req.id} Method: DELETE Api: DeleteFollow`);
+
   const { deleteFollowRequestCount, deleteFollowLatency, labels } = req.metrics;
   deleteFollowRequestCount.bind(labels).add(1);
 
@@ -117,6 +120,8 @@ exports.deleteFollow = async (req, res) => {
   const follow = await Follow.findOne({ _id: id });
 
   if (!follow) {
+    logger.warn(`Follow with id: ${id} does not exist`);
+
     return res.status(RESOURCE_NOT_FOUND_STATUS_CODE).json({
       successful: false,
       follow,
@@ -126,6 +131,8 @@ exports.deleteFollow = async (req, res) => {
 
   const latency = new Date().getTime() - requestRecieved;
   deleteFollowLatency.bind(labels).set(latency);
+
+  logger.info(`End ${req.id} Method: DELETE Api: DeleteFollow`);
 
   return res.status(OK_STATUS_CODE).json({
     successful: true,

--- a/server/tests/controllers/follow.test.js
+++ b/server/tests/controllers/follow.test.js
@@ -142,6 +142,7 @@ const buildMockRequest = () => {
   mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
   mockReq.logger.info = jest.fn();
   mockReq.logger.error = jest.fn();
+  mockReq.logger.warn = jest.fn();
 
   mockReq.metrics.createFollowRequestCount = {};
   mockReq.metrics.createFollowLatency = {};


### PR DESCRIPTION
- logged start/end of request in DeleteFollow API
- added warning log to 404 Not Found Case
- mocked request logger.warn component in unit tests
- added in latency metric for DeleteFollow API