### PR TITLE
[KAN-179] Create Notification API Request Count Metrics

### DIFF
--- a/server/src/controllers/notification.js
+++ b/server/src/controllers/notification.js
@@ -1,7 +1,6 @@
 const {
   BAD_REQUEST,
   OK_STATUS_CODE,
-  RESOURCE_NOT_FOUND_STATUS_CODE,
   DEFAULT_LIST_NOTIFICATIONS_LIMIT,
   NOTIFICATIONS_API_CONTROLLER_LOG_GROUP,
 } = require('../commons/constants');
@@ -9,6 +8,9 @@ const Notification = require('../models/notification');
 const { getPageNumber } = require('../utils/getPageNumber');
 
 exports.createNotification = async (req, res) => {
+  const { createNotificationRequestCount, labels } = req.metrics;
+  createNotificationRequestCount.bind(labels).add(1);
+
   let notification = null;
 
   try {

--- a/server/src/metrics/createMetrics.js
+++ b/server/src/metrics/createMetrics.js
@@ -4,6 +4,7 @@ const { aggregatePostMetrics } = require('./postMetrics');
 const { aggregateCommentMetrics } = require('./commentMetrics');
 const { aggregateLikeMetrics } = require('./likeMetrics');
 const { aggregateFollowMetrics } = require('./followMetrics');
+const { aggregateNotificationMetrics } = require('./notificationMetrics');
 
 exports.createMetrics = () => {
   const exporter = setUpPrometheus();
@@ -15,6 +16,7 @@ exports.createMetrics = () => {
   const commentMetrics = aggregateCommentMetrics(meter);
   const likeMetrics = aggregateLikeMetrics(meter);
   const followMetrics = aggregateFollowMetrics(meter);
+  const notificationMetrics = aggregateNotificationMetrics(meter);
   const labels = meter.labels({});
 
   return {
@@ -22,6 +24,7 @@ exports.createMetrics = () => {
     ...commentMetrics,
     ...likeMetrics,
     ...followMetrics,
+    ...notificationMetrics,
     labels,
   };
 };

--- a/server/src/metrics/notificationMetrics.js
+++ b/server/src/metrics/notificationMetrics.js
@@ -1,0 +1,23 @@
+const CREATE_NOTIFICATION_REQUEST_COUNT = 'CreateNotification_RequestCount';
+
+exports.aggregateNotificationMetrics = (meter) => {
+  const createNotificationRequestCountData =
+    buildCreateNotificationRequestCountData();
+  const createNotificationRequestCount = meter.createCounter(
+    createNotificationRequestCountData.name,
+    createNotificationRequestCountData.metadata
+  );
+
+  return {
+    createNotificationRequestCount: createNotificationRequestCount,
+  };
+};
+
+const buildCreateNotificationRequestCountData = () => {
+  return {
+    name: CREATE_NOTIFICATION_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of CreateNotification API reqeusts',
+    },
+  };
+};

--- a/server/tests/controllers/notification.test.js
+++ b/server/tests/controllers/notification.test.js
@@ -9,12 +9,13 @@ test('create_Notification_success', async () => {
   const mockOwner = 'abc';
   const mockSender = 'xyz';
   const mockRead = true;
-  const mockBody = {
+  const mockReq = buildMockRequest();
+  mockReq.body = {
     owner: mockOwner,
     sender: mockSender,
     read: mockRead,
   };
-  const mockReq = { body: mockBody };
+
   const mockRes = buildMockResponse();
 
   jest.spyOn(Notification, 'create').mockResolvedValue({});
@@ -32,12 +33,12 @@ test('create_Notification_returns_400', async () => {
   const mockOwner = 'abc';
   const mockSender = 'xyz';
   const mockRead = true;
-  const mockBody = {
+  const mockReq = buildMockRequest();
+  mockReq.body = {
     owner: mockOwner,
     sender: mockSender,
     read: mockRead,
   };
-  const mockReq = { body: mockBody };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Notification, 'create').mockRejectedValue(new Error());
@@ -100,9 +101,19 @@ const buildMockResponse = () => {
 };
 
 const buildMockRequest = () => {
-  const mockReq = { logger: {} };
+  const mockReq = { metrics: {}, logger: {} };
   mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
   mockReq.logger.info = jest.fn();
+
+  mockReq.metrics.createNotificationRequestCount = {};
+
+  const createNotificationRequestCount =
+    mockReq.metrics.createNotificationRequestCount;
+
+  createNotificationRequestCount.bind = jest.fn(
+    () => createNotificationRequestCount
+  );
+  createNotificationRequestCount.add = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
- injected RequestCount metric into CreateNotification API controller
- modified unit test to integrate new metric logic
- test locally via local host