### PR TITLE
[KAN-181] Create Notifications API Request Start/Error/End Logs

### DIFF
--- a/server/src/controllers/notification.js
+++ b/server/src/controllers/notification.js
@@ -10,6 +10,9 @@ const { getPageNumber } = require('../utils/getPageNumber');
 exports.createNotification = async (req, res) => {
   const requestRecieved = new Date().getTime();
 
+  const logger = req.logger.getLogGroup(NOTIFICATIONS_API_CONTROLLER_LOG_GROUP);
+  logger.info(`START ${req.id} Method: POST Api: CreateNotification`);
+
   const { createNotificationRequestCount, createNotificationLatency, labels } =
     req.metrics;
 
@@ -28,6 +31,8 @@ exports.createNotification = async (req, res) => {
     const latency = new Date().getTime() - requestRecieved;
     createNotificationLatency.bind(labels).set(latency);
 
+    logger.error(error);
+
     return res.status(BAD_REQUEST).json({
       successful: false,
       notification,
@@ -36,6 +41,8 @@ exports.createNotification = async (req, res) => {
 
   const latency = new Date().getTime() - requestRecieved;
   createNotificationLatency.bind(labels).set(latency);
+
+  logger.info(`END ${req.id} Method: POST Api: CreateNotification`);
 
   return res.status(OK_STATUS_CODE).json({
     successful: true,

--- a/server/tests/controllers/notification.test.js
+++ b/server/tests/controllers/notification.test.js
@@ -104,6 +104,7 @@ const buildMockRequest = () => {
   const mockReq = { metrics: {}, logger: {} };
   mockReq.logger.getLogGroup = jest.fn(() => mockReq.logger);
   mockReq.logger.info = jest.fn();
+  mockReq.logger.error = jest.fn();
 
   mockReq.metrics.createNotificationRequestCount = {};
   mockReq.metrics.createNotificationLatency = {};


### PR DESCRIPTION
- logged start/end of request in CreateNotification API
- added error log to 400 Bad Request Case
- mocked request logger.error component in unit tests