### PR TITLE
[KAN-184] Update Notifications API Request Count Metric

### DIFF
--- a/server/src/controllers/notification.js
+++ b/server/src/controllers/notification.js
@@ -81,6 +81,9 @@ exports.listNotifications = async (req, res) => {
 };
 
 exports.updateNotifications = async (req, res) => {
+  const { updateNotificationsRequestCount, labels } = req.metrics;
+  updateNotificationsRequestCount.bind(labels).add(1);
+
   const { username } = req.params;
   await Notification.updateMany({ owner: username }, { read: true });
 

--- a/server/src/metrics/notificationMetrics.js
+++ b/server/src/metrics/notificationMetrics.js
@@ -2,6 +2,7 @@ const CREATE_NOTIFICATION_REQUEST_COUNT = 'CreateNotification_RequestCount';
 const CREATE_NOTIFICATION_LATENCY = 'CreateNotification_Latency';
 const LIST_NOTIFICATIONS_REQUEST_COUNT = 'ListNotifications_RequestCount';
 const LIST_NOTIFICATIONS_LATENCY = 'listNotifications_Latency';
+const UPDATE_NOTIFICATIONS_REQUEST_COUNT = 'updateNotifications_RequestCount';
 
 exports.aggregateNotificationMetrics = (meter) => {
   const createNotificationRequestCountData =
@@ -30,11 +31,19 @@ exports.aggregateNotificationMetrics = (meter) => {
     listNotificationsLatencyData.metadata
   );
 
+  const updateNotificationsRequestCountData =
+    buildUpdateNotificationsRequestCountData();
+  const updateNotificationsRequestCount = meter.createCounter(
+    updateNotificationsRequestCountData.name,
+    updateNotificationsRequestCountData.metadata
+  );
+
   return {
     createNotificationRequestCount: createNotificationRequestCount,
     createNotificationLatency: createNotificationLatency,
     listNotificationsRequestCount: listNotificationsRequestCount,
     listNotificationsLatency: listNotificationsLatency,
+    updateNotificationsRequestCount: updateNotificationsRequestCount,
   };
 };
 
@@ -70,6 +79,15 @@ const buildListNotificationsLatencyData = () => {
     name: LIST_NOTIFICATIONS_LATENCY,
     metadata: {
       description: 'Records the latency of ListNotifications API',
+    },
+  };
+};
+
+const buildUpdateNotificationsRequestCountData = () => {
+  return {
+    name: UPDATE_NOTIFICATIONS_REQUEST_COUNT,
+    metadata: {
+      description: 'Count total number of UpdateNotifications API requests',
     },
   };
 };

--- a/server/tests/controllers/notification.test.js
+++ b/server/tests/controllers/notification.test.js
@@ -77,7 +77,8 @@ test('list_Notifications_Success', async () => {
 
 test('update_Notification_Success', async () => {
   const mockUsername = 'abcd';
-  const mockReq = { params: { username: mockUsername } };
+  const mockReq = buildMockRequest();
+  mockReq.params = { username: mockUsername };
   const mockRes = buildMockResponse();
 
   jest.spyOn(Notification, 'updateMany').mockResolvedValue([{}]);
@@ -131,6 +132,15 @@ const buildMockRequest = () => {
   listNotificationsRequestCount.add = jest.fn();
   listNotificationsLatency.bind = jest.fn(() => listNotificationsLatency);
   listNotificationsLatency.set = jest.fn();
+
+  mockReq.metrics.updateNotificationsRequestCount = {};
+
+  const { updateNotificationsRequestCount } = mockReq.metrics;
+
+  updateNotificationsRequestCount.bind = jest.fn(
+    () => updateNotificationsRequestCount
+  );
+  updateNotificationsRequestCount.add = jest.fn();
 
   return mockReq;
 };


### PR DESCRIPTION
-injected RequestCount metric into UpdateNotifications API controller
-modified unit test to integrate new metric logic
-test locally via local host